### PR TITLE
Fixed issues when onboarding HA setup, and issues with Health Check script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ CMD ["powershell", "C:/SHIR/setup.ps1"]
 
 ENV SHIR_WINDOWS_CONTAINER_ENV True
 
-# HEALTHCHECK --start-period=120s CMD ["powershell", "C:/SHIR/health-check.ps1"]
+HEALTHCHECK --start-period=120s CMD ["powershell", "C:/SHIR/health-check.ps1"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ CMD ["powershell", "C:/SHIR/setup.ps1"]
 
 ENV SHIR_WINDOWS_CONTAINER_ENV True
 
-HEALTHCHECK --start-period=120s CMD ["powershell", "C:/SHIR/health-check.ps1"]
+# HEALTHCHECK --start-period=120s CMD ["powershell", "C:/SHIR/health-check.ps1"]

--- a/SHIR/health-check.ps1
+++ b/SHIR/health-check.ps1
@@ -1,9 +1,48 @@
 $DmgcmdPath = "C:\Program Files\Microsoft Integration Runtime\5.0\Shared\dmgcmd.exe"
 
+function Run-Process([string] $process, [string] $arguments)
+{
+	Write-Verbose "Run-Process: $process $arguments"
+	
+	$errorFile = "$env:tmp\tmp$pid.err"
+	$outFile = "$env:tmp\tmp$pid.out"
+	"" | Out-File $outFile
+	"" | Out-File $errorFile	
+
+	$errVariable = ""
+
+	if ([string]::IsNullOrEmpty($arguments))
+	{
+		$proc = Start-Process -FilePath $process -Wait -Passthru -NoNewWindow `
+			-RedirectStandardError $errorFile -RedirectStandardOutput $outFile -ErrorVariable errVariable
+	}
+	else
+	{
+		$proc = Start-Process -FilePath $process -ArgumentList $arguments -Wait -Passthru -NoNewWindow `
+			-RedirectStandardError $errorFile -RedirectStandardOutput $outFile -ErrorVariable errVariable
+	}
+	
+	$errContent = [string] (Get-Content -Path $errorFile -Delimiter "!!!DoesNotExist!!!")
+	$outContent = [string] (Get-Content -Path $outFile -Delimiter "!!!DoesNotExist!!!")
+
+	Remove-Item $errorFile
+	Remove-Item $outFile
+
+	if($proc.ExitCode -ne 0 -or $errVariable -ne "")
+	{		
+		Throw-Error "Failed to run process: exitCode=$($proc.ExitCode), errVariable=$errVariable, errContent=$errContent, outContent=$outContent."
+	}
+
+	if ([string]::IsNullOrEmpty($outContent))
+	{
+		return $outContent
+	}
+
+	return $outContent.Trim()
+}
 function Check-Node-Connection() {
-    Start-Process $DmgcmdPath -Wait -ArgumentList "-cgc" -RedirectStandardOutput "C:\SHIR\status-check.txt"
-    $ConnectionResult = Get-Content "C:\SHIR\status-check.txt"
-    Remove-Item -Force "C:\SHIR\status-check.txt"
+
+    $ConnectionResult = Run-Process $DmgcmdPath "-cgc"
 
     if ($ConnectionResult -like "Connected") {
         return $TRUE

--- a/SHIR/setup.ps1
+++ b/SHIR/setup.ps1
@@ -47,17 +47,15 @@ function RegisterNewNode {
     )
 
     Write-Log "Start registering the new SHIR node"
-
+    if ($ENABLE_HA -eq "true") {
+        Write-Log "Enable High Availability"
+        $PORT = if (!$HA_PORT) { "8060" } else { $HA_PORT }
+        Start-Process $DmgcmdPath -Wait -ArgumentList "-EnableRemoteAccessInContainer", "$($PORT)" -RedirectStandardOutput "C:\SHIR\register-out.txt" -RedirectStandardError "C:\SHIR\register-error.txt"
+    }
     if (!$NODE_NAME) {
         Start-Process $DmgcmdPath -Wait -ArgumentList "-RegisterNewNode", "$($AUTH_KEY)" -RedirectStandardOutput "C:\SHIR\register-out.txt" -RedirectStandardError "C:\SHIR\register-error.txt"
     } else {
         Start-Process $DmgcmdPath -Wait -ArgumentList "-RegisterNewNode", "$($AUTH_KEY)", "$($NODE_NAME)" -RedirectStandardOutput "C:\SHIR\register-out.txt" -RedirectStandardError "C:\SHIR\register-error.txt"
-    }
-
-    if ($ENABLE_HA -eq "true") {
-        Write-Log "Enable High Availability"
-        $PORT = $HA_PORT -or "8060"
-        Start-Process $DmgcmdPath -Wait -ArgumentList "-EnableRemoteAccess", "$($PORT)"
     }
 
     $StdOutResult = Get-Content "C:\SHIR\register-out.txt"


### PR DESCRIPTION
I ran into the following issues when setting up 2 containers in HA mode - this PR contains fixes for all 3 issues. 

### Issue
[health-check.ps1 logic is faulty, when setup.ps1 is accessing status-check.txt, the container shuts down](https://github.com/Azure/Azure-Data-Factory-Integration-Runtime-in-Windows-Container/issues/2)

### Resolution
Added new function `Run-Process` that uses a temporary file based on the process ID to grab the output within the function and performs cleanup. This avoids the above issue with file conflicts with `setup.ps1` that was causing the issue.

### Issue
[Passing in HA_PORT doesn't work, as $PORT isn't being passed in correctly in code](https://github.com/Azure/Azure-Data-Factory-Integration-Runtime-in-Windows-Container/issues/3)

### Resolution
Changed to `$PORT = if (!$HA_PORT) { "8060" } else { $HA_PORT }`

### Issue
[Adding second container doesn't work for HA due to order of operations and incorrect remote access command](https://github.com/Azure/Azure-Data-Factory-Integration-Runtime-in-Windows-Container/issues/4)

### Resolution
1. Changed from `-EnableRemoteAccess` to `-EnableRemoteAccessInContainer` 
2.  Switched order of execution - `-EnableRemoteAccessInContainer` then `-RegisterNewNode`

I've tested running 2 containers in HA mode, it's now working with the Health Check enabled:
![image](https://user-images.githubusercontent.com/46581776/120936564-78fbc900-c6d6-11eb-94d3-84c1ed30297d.png)