### PR TITLE
Update Dockerfile to make container build process more comprehensive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2019
 # Download the latest self-hosted integration runtime installer into the SHIR folder
 COPY SHIR C:/SHIR/
 
-RUN ["curl" "-L" "https://go.microsoft.com/fwlink/?linkid=839822&clcid=0x409" "--output" "C:/SHIR/SHIR.msi"]
+RUN ["curl", "-L", "https://go.microsoft.com/fwlink/?linkid=839822&clcid=0x409", "-o", "C:/SHIR/SHIR.msi"]
 
 RUN ["powershell", "C:/SHIR/build.ps1"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2019
 # Download the latest self-hosted integration runtime installer into the SHIR folder
 COPY SHIR C:/SHIR/
 
-ADD https://download.microsoft.com/download/E/4/7/E4771905-1079-445B-8BF9-8A1A075D8A10/IntegrationRuntime_5.17.8186.1.msi C:/SHIR/
+ADD https://go.microsoft.com/fwlink/?linkid=839822&clcid=0x409 C:/SHIR/
 
 RUN ["powershell", "C:/SHIR/build.ps1"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2019
 # Download the latest self-hosted integration runtime installer into the SHIR folder
 COPY SHIR C:/SHIR/
 
-RUN ["curl", "-L", "https://go.microsoft.com/fwlink/?linkid=839822&clcid=0x409", "-o", "C:/SHIR/SHIR.msi"]
+RUN ["curl", "-L", "https://go.microsoft.com/fwlink/?linkid=839822&clcid=0x409", "-o", "C:/SHIR/IntegrationRuntime.latest.msi"]
 
 RUN ["powershell", "C:/SHIR/build.ps1"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2019
 # Download the latest self-hosted integration runtime installer into the SHIR folder
 COPY SHIR C:/SHIR/
 
-RUN ["curl", "-L", "https://go.microsoft.com/fwlink/?linkid=839822&clcid=0x409", "-o", "C:/SHIR/IntegrationRuntime.latest.msi"]
-
 RUN ["powershell", "C:/SHIR/build.ps1"]
 
 ENTRYPOINT ["powershell", "C:/SHIR/setup.ps1"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2019
 # Download the latest self-hosted integration runtime installer into the SHIR folder
 COPY SHIR C:/SHIR/
 
-ADD https://go.microsoft.com/fwlink/?linkid=839822&clcid=0x409 C:/SHIR/
+RUN curl -L 'https://go.microsoft.com/fwlink/?linkid=839822&clcid=0x409' --output C:/SHIR/SHIR.msi
 
 RUN ["powershell", "C:/SHIR/build.ps1"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2019
 # Download the latest self-hosted integration runtime installer into the SHIR folder
 COPY SHIR C:/SHIR/
 
-RUN curl -L 'https://go.microsoft.com/fwlink/?linkid=839822&clcid=0x409' --output C:/SHIR/SHIR.msi
+RUN curl -L https://go.microsoft.com/fwlink/?linkid=839822&clcid=0x409 --output C:/SHIR/SHIR.msi
 
 RUN ["powershell", "C:/SHIR/build.ps1"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2019
 # Download the latest self-hosted integration runtime installer into the SHIR folder
 COPY SHIR C:/SHIR/
 
+ADD https://download.microsoft.com/download/E/4/7/E4771905-1079-445B-8BF9-8A1A075D8A10/IntegrationRuntime_5.17.8186.1.msi C:/SHIR/
+
 RUN ["powershell", "C:/SHIR/build.ps1"]
 
 CMD ["powershell", "C:/SHIR/setup.ps1"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ADD https://download.microsoft.com/download/E/4/7/E4771905-1079-445B-8BF9-8A1A07
 
 RUN ["powershell", "C:/SHIR/build.ps1"]
 
-CMD ["powershell", "C:/SHIR/setup.ps1"]
+ENTRYPOINT ["powershell", "C:/SHIR/setup.ps1"]
 
 ENV SHIR_WINDOWS_CONTAINER_ENV True
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2019
 # Download the latest self-hosted integration runtime installer into the SHIR folder
 COPY SHIR C:/SHIR/
 
-RUN curl -L https://go.microsoft.com/fwlink/?linkid=839822&clcid=0x409 --output C:/SHIR/SHIR.msi
+RUN ["curl" "-L" "https://go.microsoft.com/fwlink/?linkid=839822&clcid=0x409" "--output" "C:/SHIR/SHIR.msi"]
 
 RUN ["powershell", "C:/SHIR/build.ps1"]
 

--- a/SHIR/build.ps1
+++ b/SHIR/build.ps1
@@ -8,9 +8,22 @@ function Write-Log($Message) {
 function Install-SHIR() {
     Write-Log "Install the Self-hosted Integration Runtime in the Windows container"
 
-    $MsiFileName = (Get-ChildItem -Path C:\SHIR | Where-Object { $_.Name -match [regex] "IntegrationRuntime.*.msi" })[0].Name
-    Write-Log $MsiFileName
+    $MsiFiles = (Get-ChildItem -Path C:\SHIR | Where-Object { $_.Name -match [regex] "IntegrationRuntime.*.msi" })
+    if ($MsiFiles) {
+        $MsiFileName = $MsiFiles[0].Name
+        Write-Log "Using SHIR MSI file: $MsiFileName"
+    }
+    else {
+        Write-Log "Downloading latest version of SHIR MSI file"
+        $MsiFileName = 'IntegrationRuntime.latest.msi'
 
+        # Temporarily disable progress updates to speed up the download process. (See https://stackoverflow.com/questions/69942663/invoke-webrequest-progress-becomes-irresponsive-paused-while-downloading-the-fil)
+        $ProgressPreference = 'SilentlyContinue'
+        Invoke-WebRequest -Uri 'https://go.microsoft.com/fwlink/?linkid=839822&clcid=0x409' -OutFile "C:\SHIR\$MsiFileName"
+        $ProgressPreference = 'Continue'
+    }
+
+    Write-Log "Installing SHIR"
     Start-Process msiexec.exe -Wait -ArgumentList "/i C:\SHIR\$MsiFileName /qn"
     if (!$?) {
         Write-Log "SHIR MSI Install Failed"


### PR DESCRIPTION
This PR makes two changes to the Dockerfile for this container image:

1. It downloads the SHIR MSI file automatically as part of the container build process.

1. It uses the `ENTRYPOINT` instruction instead of `CMD`. This ensures that the SHIR always starts when the container starts, including on platforms like Azure App Service that don't automatically run `CMD` instructions.