### PR TITLE
Update the description for ENABLE_AE flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For more information about Azure Data Factory, see [https://docs.microsoft.com/e
 | `NODE_NAME` | Optional | `hostname` | The specified name of the node. |
 | `ENABLE_HA` | Optional | `false` | The flag to enable high availability and scalability.<br/> It supports up to 4 nodes registered to the same IR when `HA` is enabled, otherwise only 1 is allowed. |
 | `HA_PORT` | Optional | `8060` | The port to set up a high availability cluster. |
-| `ENABLE_AE` | Optional | `false` | The flag to enable offline nodes auto-expiration.<br/> If enabled, the expired nodes will be removed automatically from the IR when a new node is attempting to register.<br/> Only works when `ENABLE_HA=true`. |
+| `ENABLE_AE` | Optional | `false` | The flag to enable offline nodes auto-expiration.<br/> If enabled, the node will be marked as expired when it has been offline for timeout duration defined by `AE_TIME`. |
 | `AE_TIME` | Optional | `600` |  The expiration timeout duration for offline nodes in seconds. <br/>Should be no less than 600 (10 minutes). |
 
 # Contributing


### PR DESCRIPTION
Expired nodes will be removed on Azure Portal automatically now. 
After that, new node registration is allowed even though `ENABLE_HA` is set as `false`.