### PR TITLE
Referencing environment variables instead of locally scoped variables

### DIFF
--- a/SHIR/setup.ps1
+++ b/SHIR/setup.ps1
@@ -90,7 +90,7 @@ if (Check-Is-Registered) {
     if ((Test-Path Env:ENABLE_HA) -and ($Env:ENABLE_HA -eq "true")) {
         Write-Log "Enable High Availability"
         $PORT = $Env:$HA_PORT
-        if (!$HA_PORT) {
+        if (!$Env:HA_PORT) {
             $PORT = "8060"
         }
         Write-Log "Remote Access Port: $($PORT)"

--- a/SHIR/setup.ps1
+++ b/SHIR/setup.ps1
@@ -87,9 +87,9 @@ function RegisterNewNode {
 if (Check-Is-Registered) {
     Write-Log "Restart the existing node"
 
-    if ($ENABLE_HA -eq "true") {
+    if ((Test-Path Env:ENABLE_HA) -and ($Env:ENABLE_HA -eq "true")) {
         Write-Log "Enable High Availability"
-        $PORT = $HA_PORT
+        $PORT = $Env:$HA_PORT
         if (!$HA_PORT) {
             $PORT = "8060"
         }

--- a/SHIR/setup.ps1
+++ b/SHIR/setup.ps1
@@ -89,7 +89,7 @@ if (Check-Is-Registered) {
 
     if ((Test-Path Env:ENABLE_HA) -and ($Env:ENABLE_HA -eq "true")) {
         Write-Log "Enable High Availability"
-        $PORT = $Env:$HA_PORT
+        $PORT = $Env:HA_PORT
         if (!$Env:HA_PORT) {
             $PORT = "8060"
         }


### PR DESCRIPTION
When running:

```sh
> docker run -d -e AUTH_KEY=<ir-authentication-key> \
    [-e NODE_NAME=<ir-node-name>] \
    [-e ENABLE_HA={true|false}] \
    [-e HA_PORT=<port>] \
    [-e ENABLE_AE={true|false}] \
    [-e AE_TIME=<expiration-time-in-seconds>] \
    <image-name>
```

as defined in the README, the entry point of the container is 

```docker
ENTRYPOINT ["powershell", "C:/SHIR/setup.ps1"]
```

This implies `ENABLE_HA` and `HA_PORT` are considered environment variables when the main section of `setup.ps1` runs. This change references the environment variables `$Env:ENABLE_HA` and `$Env:HA_PORT`  in the main section instead of `setup.ps1` instead of `$ENABLE_HA` and `$HA_PORT` since the locally scoped variables are undefined initially.