### PR TITLE
Minor fixes/tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ For more information about Azure Data Factory, see [https://docs.microsoft.com/e
     [-e HA_PORT=<port>] \
     [-e ENABLE_AE={true|false}] \
     [-e AE_TIME=<expiration-time-in-seconds>] \
+    [-e TZ=<time-zone-name>] \
     <image-name>
 ```
 ### __Arguments list__
@@ -35,6 +36,7 @@ For more information about Azure Data Factory, see [https://docs.microsoft.com/e
 | `HA_PORT` | Optional | `8060` | The port to set up a high availability cluster. |
 | `ENABLE_AE` | Optional | `false` | The flag to enable offline nodes auto-expiration.<br/> If enabled, the node will be marked as expired when it has been offline for timeout duration defined by `AE_TIME`. |
 | `AE_TIME` | Optional | `600` |  The expiration timeout duration for offline nodes in seconds. <br/>Should be no less than 600 (10 minutes). |
+| `TZ` | Optional | `UTC` | Valid values can be found as Id from the command `Get-TimeZone -List` |
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ For more information about Azure Data Factory, see [https://docs.microsoft.com/e
 |---|---|---|---|
 | `AUTH_KEY` | Required | | The authentication key for the self-hosted integration runtime. |
 | `NODE_NAME` | Optional | `hostname` | The specified name of the node. |
-| `ENABLE_HA` | Optional | `false` | The flag to enable high availability and scalability.<br/> It supports up to 4 nodes registered to the same IR when `HA` is enabled, otherwise only 1 is allowed. |
+| `ENABLE_HA` | Optional | `false` | The flag to enable high availability and scalability.<br/> It supports up to 4 nodes registered to the same IR when `HA` is enabled, otherwise only 1 is allowed. If set to true and in a kubernetes cluster - consider setting [spec.template.spec.dnsConfig.searches](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#hostname-and-name-resolution) to `service`.`namespace`.`svc.cluster.local` to allow intra-pod communications |
 | `HA_PORT` | Optional | `8060` | The port to set up a high availability cluster. |
 | `ENABLE_AE` | Optional | `false` | The flag to enable offline nodes auto-expiration.<br/> If enabled, the node will be marked as expired when it has been offline for timeout duration defined by `AE_TIME`. |
 | `AE_TIME` | Optional | `600` |  The expiration timeout duration for offline nodes in seconds. <br/>Should be no less than 600 (10 minutes). |

--- a/SHIR/build.ps1
+++ b/SHIR/build.ps1
@@ -64,7 +64,30 @@ function SetupEnv() {
     Write-Log "SHIR Environment Setup Successfully"
 }
 
+function Add-Monitor-User($theUser) {
+    try {
+        Add-LocalGroupMember -Group "Performance Monitor Users" -Member $theUser
+    } catch {
+        Write-Log "The user $theUser was already in the Performance Monitor Users group"
+    }
+    try {
+        Add-LocalGroupMember -Group "Performance Log Users" -Member $theUser
+    } catch {
+        Write-Log "The user $theUser was already in the Performance Log Users group"
+    }
+    Write-Log "The user $theUser is now in groups Performance Monitor Users and Performance Log Users"
+  }  
+
 Install-SHIR
+
+# #######################################################
+# Add user to the monitoring groups
+# the current user was fetched from a running pod using the below code
+# $currentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+Add-Monitor-User "User Manager\ContainerAdministrator"  # This is the user that a user will enter as when logging into the container
+Add-Monitor-User "NT SERVICE\DIAHostService"            # This is the user that runs the SHIR backend
+
+
 if ([bool]::Parse($env:INSTALL_JDK)) {
     Install-MSFT-JDK
 }

--- a/SHIR/health-check.ps1
+++ b/SHIR/health-check.ps1
@@ -1,9 +1,10 @@
 $DmgcmdPath = "C:\Program Files\Microsoft Integration Runtime\5.0\Shared\dmgcmd.exe"
 
 function Check-Node-Connection() {
-    Start-Process $DmgcmdPath -Wait -ArgumentList "-cgc" -RedirectStandardOutput "C:\SHIR\status-check.txt"
-    $ConnectionResult = Get-Content "C:\SHIR\status-check.txt"
-    Remove-Item -Force "C:\SHIR\status-check.txt"
+    $outputFile = "C:\SHIR\status-check-$([guid]::NewGuid().ToString()).txt"
+    Start-Process $DmgcmdPath -Wait -ArgumentList "-cgc" -RedirectStandardOutput $outputFile
+    $ConnectionResult = Get-Content $outputFile
+    Remove-Item -Force $outputFile
 
     if ($ConnectionResult -like "Connected") {
         return $TRUE

--- a/SHIR/setup.ps1
+++ b/SHIR/setup.ps1
@@ -83,6 +83,16 @@ function RegisterNewNode {
     }
 }
 
+
+# Set timezone if set from input
+If (Test-Path Env.TZ) {
+    try { 
+        Set-TimeZone -Id $Env:TZ 
+    } catch {
+        Write-Log "Unable to set the $Env:TZ timezone"
+    }
+}
+
 # Register SHIR with key from Env Variable: AUTH_KEY
 if (Check-Is-Registered) {
     Write-Log "Restart the existing node"


### PR DESCRIPTION
This attempts to address

- health-check.ps1 single state file issue
- resolve issue with performance counter
- option to set timezone
- HA setup note

**health-check.ps1**
The health-check.ps1 was using a common file while at the same time kubernetes may call two different probes (readiness / liveness) at the same time. This may cause issues or unclear results. By setting the common file unique this is avoided.

**performance counter**
The Self Hosted Integration Runtime generates logs into the LogName "Integration Runtime". While analyzing the errors from this we noted that the installer does not automatically add the service user (NT SERVICE\DIAHostService) to the groups "Performance Monitor Users" and "Performance Log Users". This user is running the backend services. 
When the DIAHostService user was added to the groups the errors were mostly removed. The SHIR still looks for some counters which does not exists due to being in a virtual environment. This is more like a program bug.

Typical errors seen in the log without this fix

- DEBUG:   System.UnauthorizedAccessException: Access to the registry key 'Global' 
- Failed to get performance   counter: Free Megabytes. 
- Failed to get performance   counter: Committed Bytes. 
- Failed to get performance   counter: Commit Limit. 
- Failed to get performance   counter: Network Interface. 
- Failed to get performance   counter: % Processor Time. 
- Failed to get performance   counter: Available MBytes. 
- Failed to get performance   counter: % Committed Bytes In use. 

After the fix some of the "Free Megabytes" errors remains while the others are fully resolved.

**Timezone**
This may be a "me" problem? I was unable to (easily) set the windows timezone from the deployment specification (at least for me the TZ setting did not work). This resolves the issue. README.md updated

**HA and communications**
Just a short note in README.md about the kubernetes setup.
