### PR TITLE
Certificate and Java update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2019
 ARG INSTALL_JDK=false
+ARG INSTALL_CERT=false
 
 # Download the latest self-hosted integration runtime installer into the SHIR folder
 COPY SHIR C:/SHIR/

--- a/README.md
+++ b/README.md
@@ -10,12 +10,13 @@ For more information about Azure Data Factory, see [https://docs.microsoft.com/e
 1. Prepare [Windows for containers](https://learn.microsoft.com/en-us/virtualization/windowscontainers/quick-start/set-up-environment?tabs=dockerce)
 2. Build the Windows container image in the project folder
 ```bash
-> docker build . -t <image-name> [--build-arg="INSTALL_JDK=true"]
+> docker build . -t <image-name> [--build-arg="INSTALL_JDK=true"] [--build-arg="INSTALL_CERT=true"]
 ```
 ### __Arguments list__
 |Name|Necessity|Default|Description|
 |---|---|---|---|
-| `INSTALL_JDK` | Optional | `false` | The flag to install Microsoft's JDK 11 LTS. |
+| `INSTALL_JDK` | Optional | `false` | The flag to install Microsoft's JDK 21 LTS. |
+| `INSTALL_CERT` | Optional | `false` | The flag to install Root or Intermittent certificate files and must match regex format [root.*.cer] or [intermittent.*.cer] to work. |
 3. Run the container with specific arguments by passing environment variables
 ```bash
 > docker run -d -e AUTH_KEY=<ir-authentication-key> \

--- a/SHIR/build.ps1
+++ b/SHIR/build.ps1
@@ -75,7 +75,25 @@ function Add-Monitor-User($theUser) {
         Write-Log "The user $theUser was already in the Performance Log Users group"
     }
     Write-Log "The user $theUser is now in groups Performance Monitor Users and Performance Log Users"
-  }  
+}
+
+Function Install-Certificate {
+    $rootcert = (Get-ChildItem -Path C:\SHIR | Where-Object { $_.Name -match [regex] "root.*.cer" })
+    $intermittent = (Get-ChildItem -Path C:\SHIR | Where-Object { $_.Name -match [regex] "intermittent.*.cer" })
+    if($rootcert) {
+        Write-Log "Installing Root Certificate"
+        Import-Certificate -FilePath "C:\SHIR\$rootcert" -CertStoreLocation Cert:\LocalMachine\Root
+        Write-Log "Will remove C:\SHIR\$rootcert"
+        Remove-Item "C:\SHIR\$rootcert"
+
+    }
+    if($intermittent) {
+        Write-Log "Installing Intermittent Certificate"
+        Import-Certificate -FilePath "C:\SHIR\$intermittent" -CertStoreLocation Cert:\LocalMachine\CA
+        Write-Log "Will remove C:\SHIR\$intermittent"
+        Remove-Item "C:\SHIR\$intermittent"
+    }
+}
 
 Install-SHIR
 
@@ -89,6 +107,10 @@ Add-Monitor-User "NT SERVICE\DIAHostService"            # This is the user that 
 
 if ([bool]::Parse($env:INSTALL_JDK)) {
     Install-MSFT-JDK
+}
+
+if ([bool]::Parse($env:INSTALL_CERT)) {
+    Install-Certificate
 }
 
 exit 0

--- a/SHIR/build.ps1
+++ b/SHIR/build.ps1
@@ -38,7 +38,7 @@ function Install-SHIR() {
 function Install-MSFT-JDK() {
     Write-Log "Install the Microsoft OpenJDK in the Windows container"
     Write-Log "Downloading Microsoft OpenJDK 21 LTS msi"
-    $JDKMsiFileName = 'microsoft-jdk-21.0.4-windows-x64.msi'
+    $JDKMsiFileName = 'microsoft-jdk-21-windows-x64.msi'
 
     # Temporarily disable progress updates to speed up the download process. (See https://stackoverflow.com/questions/69942663/invoke-webrequest-progress-becomes-irresponsive-paused-while-downloading-the-fil)
     $ProgressPreference = 'SilentlyContinue'

--- a/SHIR/build.ps1
+++ b/SHIR/build.ps1
@@ -37,9 +37,8 @@ function Install-SHIR() {
 
 function Install-MSFT-JDK() {
     Write-Log "Install the Microsoft OpenJDK in the Windows container"
-
-    Write-Log "Downloading Microsoft OpenJDK 11 LTS msi"
-    $JDKMsiFileName = 'microsoft-jdk-11-windows-x64.msi'
+    Write-Log "Downloading Microsoft OpenJDK 21 LTS msi"
+    $JDKMsiFileName = 'microsoft-jdk-21.0.4-windows-x64.msi'
 
     # Temporarily disable progress updates to speed up the download process. (See https://stackoverflow.com/questions/69942663/invoke-webrequest-progress-becomes-irresponsive-paused-while-downloading-the-fil)
     $ProgressPreference = 'SilentlyContinue'


### PR DESCRIPTION
Added support for later versions of Java as 21 is current and works with the current builds of SHIR.

Added feature for certificates allowing containers on networks where TLS inspections are present to work.
An optional build switch supports this feature was added to make sure that is only called when needed.